### PR TITLE
feat: add song generation template

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -50,7 +50,9 @@ resonate-gem-brain/
 │     ├─ AGENTS.md
 │     ├─ namer.md
 │     ├─ descriptor.md
+│     ├─ lyricist.md
 │     ├─ sonic-architect.md
+│     ├─ cover-designer.md
 │     └─ album-designer.md
 ├─ guardrails/
 │  ├─ stylebook.md

--- a/agents/media/AGENTS.md
+++ b/agents/media/AGENTS.md
@@ -36,4 +36,5 @@ Coordinates creative media work and delegates to specialized sub-agents.
    ## Cover Prompt
    ...
    ```
-4. Return the final Markdown.
+   - Ensure the cover prompt explicitly includes the song title.
+4. Return the final Markdown and ask if the user wants the album cover generated.

--- a/agents/media/AGENTS.md
+++ b/agents/media/AGENTS.md
@@ -5,10 +5,35 @@ Coordinates creative media work and delegates to specialized sub-agents.
 ## Sub-agents
 - `namer.md` – propose titles.
 - `descriptor.md` – craft short descriptions and metadata.
-- `sonic-architect.md` – outline sonic structure.
+- `lyricist.md` – draft structured lyrics.
+- `sonic-architect.md` – outline tempo, key, instrumentation, and arrangement.
+- `cover-designer.md` – generate cover art prompts.
 - `album-designer.md` – suggest album context.
 
 ### Workflow
 1. Clarify the requested medium if unclear.
 2. Invoke relevant sub-agents and synthesize their outputs.
-3. Return a cohesive media plan in Markdown.
+3. For songs, compile results into:
+   
+   ```
+   # [Song Title]
+
+   ## Description
+   ...
+
+   ---
+
+   ## Lyrics
+   ...
+
+   ---
+
+   ## Sonic Architecture
+   ...
+
+   ---
+
+   ## Cover Prompt
+   ...
+   ```
+4. Return the final Markdown.

--- a/agents/media/cover-designer.md
+++ b/agents/media/cover-designer.md
@@ -4,3 +4,4 @@ Craft a concise text-to-image prompt for the song's cover art.
 
 - Describe scene, colors, mood, and style in ≤40 words.
 - Do not reference specific artists.
+- Include the song title text so it appears on the cover.

--- a/agents/media/cover-designer.md
+++ b/agents/media/cover-designer.md
@@ -1,0 +1,6 @@
+# Cover Designer
+
+Craft a concise text-to-image prompt for the song's cover art.
+
+- Describe scene, colors, mood, and style in ≤40 words.
+- Do not reference specific artists.

--- a/agents/media/lyricist.md
+++ b/agents/media/lyricist.md
@@ -1,0 +1,6 @@
+# Lyricist
+
+Draft song lyrics using bracketed section labels.
+
+- Include `[Intro]`, `[Verse 1]`, `[Pre-Chorus]` (optional), `[Chorus]`, `[Verse 2]`, `[Bridge]`, `[Chorus – Variation]` (optional), `[Outro]`.
+- Keep each section ≤ 6 lines.

--- a/examples/outputs.md
+++ b/examples/outputs.md
@@ -1,8 +1,35 @@
 # Output Examples
 
 ## Copy-Smith (Landing Hero)
-**H1:** Turn ideas into viral proof—today.  
-**Sub:** AI-native workflows that write, design, and iterate while you sleep.  
+**H1:** Turn ideas into viral proof—today.
+**Sub:** AI-native workflows that write, design, and iterate while you sleep.
 **CTA:** Build my first flow →
 
 *Why this works:* benefit-first, concrete promise, action CTA.
+
+## Media Agent (Song)
+# Midnight Echoes
+
+## Description
+A dark synthwave ballad of longing and neon-lit nights.
+
+---
+
+## Lyrics
+[Intro]  
+instrumental hum
+
+[Verse 1]  
+city lights in my rearview...
+
+---
+
+## Sonic Architecture
+- **Tempo:** 90 BPM
+- **Key:** A minor
+- **Style/Genre:** Synthwave
+
+---
+
+## Cover Prompt
+moody neon skyline, rain-slick streets, glowing purple and blue, cinematic

--- a/examples/outputs.md
+++ b/examples/outputs.md
@@ -32,4 +32,6 @@ city lights in my rearview...
 ---
 
 ## Cover Prompt
-moody neon skyline, rain-slick streets, glowing purple and blue, cinematic
+moody neon skyline, rain-slick streets, glowing purple and blue, cinematic, title "Midnight Echoes" in neon script
+
+Generate the album cover with this prompt?


### PR DESCRIPTION
## Summary
- expand media agent with lyricist and cover-designer sub-agents
- define song output structure with title, description, lyrics, sonic notes, and cover prompt
- document new agents in manifest and example output

## Testing
- `pytest`
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689be3fa556c83328ce4b403d3820e56